### PR TITLE
Update makefile to install to /usr/local.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 ### Code:
 
 DESTDIR=
-prefix=$(DESTDIR)/usr
+prefix=$(DESTDIR)/usr/local
 exec_prefix=$(prefix)
 bindir=$(exec_prefix)/bin
 datarootdir=$(prefix)/share


### PR DESCRIPTION
Installing to /usr/bin by default requires elevated permissions.

Changing the prefix in the makefile to /usr/local allows unprivileged install.